### PR TITLE
Formatters dir is relative to ts-loader module

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var rimraf = require("rimraf");
 function loadRelativeConfig() {
   var options = {
      formatter: "custom",
-     formattersDirectory: 'node_modules/tslint-loader/formatters/',    
+     formattersDirectory: __dirname + '/formatters/',
      configuration: {}
   };
   


### PR DESCRIPTION
Currently, the formatters dir is located relative to the CWD. This is a problem when tslint-loader is used as a transitive dependency of another project.

In our case, it makes sense to pass the exact absolute path to the formatters directory that is located within the lslint-loader module.
